### PR TITLE
feat: 채팅 목록 UI 구현 #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nuxt/ui": "^3.0.2",
         "@pinia/nuxt": "^0.10.1",
         "@unhead/vue": "^2.0.2",
+        "dayjs": "^1.11.13",
         "eslint": "^9.23.0",
         "nuxt": "^3.16.1",
         "sass-embedded": "^1.86.0",
@@ -6816,6 +6817,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/db0": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@nuxt/ui": "^3.0.2",
     "@pinia/nuxt": "^0.10.1",
     "@unhead/vue": "^2.0.2",
+    "dayjs": "^1.11.13",
     "eslint": "^9.23.0",
     "nuxt": "^3.16.1",
     "sass-embedded": "^1.86.0",

--- a/pages/chat-list.vue
+++ b/pages/chat-list.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-card
+      width="100%"
+      style="height: 100vh"
+      class="white"
+  >
+    <v-toolbar
+        class="bg-secondary text-white"
+    >
+<!--      <v-app-bar-nav-icon></v-app-bar-nav-icon>-->
+
+      <v-toolbar-title
+      class="font-weight-bold">채팅 목록</v-toolbar-title>
+
+      <v-btn icon>
+        <v-icon>mdi-magnify</v-icon>
+      </v-btn>
+
+      <v-btn icon @click="">
+        <v-icon>mdi-message-plus</v-icon>
+      </v-btn>
+      <v-btn icon>
+        <v-icon>mdi-cog</v-icon>
+      </v-btn>
+    </v-toolbar>
+
+    <v-list lines="two">
+      <v-list-item
+          v-for="(item, index) in items"
+          :key="index"
+          :prepend-avatar="item.avatar"
+          @click=""
+      >
+
+        <template #title>
+          <div class="text-primary font-weight-bold">
+            {{ item.name }}
+          </div>
+        </template>
+        <template #subtitle>
+          {{ item.lastMessage.message }}
+        </template>
+        <template #append>
+          <div class="text-caption">
+            {{ formatTime(item.lastMessage.sendAt) }}
+          </div>
+        </template>
+      </v-list-item>
+    </v-list>
+
+  </v-card>
+</template>
+
+<script setup lang="ts">
+
+import dayjs from 'dayjs'
+import isToday from 'dayjs/plugin/isToday'
+import isYesterday from 'dayjs/plugin/isYesterday'
+import weekday from 'dayjs/plugin/weekday'
+import localeData from 'dayjs/plugin/localeData'
+import 'dayjs/locale/ko'
+
+dayjs.extend(isToday)
+dayjs.extend(isYesterday)
+dayjs.extend(weekday)
+dayjs.extend(localeData)
+dayjs.locale('ko')
+
+function formatTime(dateStr: string) {
+  const date = dayjs(dateStr)
+  if (date.isToday()) return date.format('HH:mm')
+  if (date.isYesterday()) return '어제'
+  if (dayjs().diff(date, 'day') < 7) return date.format('ddd') // 월, 화, 수...
+  return date.format('YYYY-MM-DD')
+}
+
+// todo 임시 데이터
+const items = [
+  {
+    avatar: 'https://picsum.photos/250/300?image=660',
+    name: "유저이름",
+    lastMessage:{
+      message: '마지막 메시지',
+      sendAt: '2025-04-13 14:38:40'
+    },
+  },
+  {
+    avatar: 'https://picsum.photos/250/300?image=660',
+    name: "유저이름",
+    lastMessage:{
+      message: '마지막 메시지',
+      sendAt: '2025-04-13 14:38:40'
+    },
+  },
+  {
+    avatar: 'https://picsum.photos/250/300?image=660',
+    name: "유저이름",
+    lastMessage:{
+      message: '마지막 메시지',
+      sendAt: '2025-04-10 14:38:40'
+    },
+  },
+  {
+    avatar: 'https://picsum.photos/250/300?image=660',
+    name: "유저이름",
+    lastMessage:{
+      message: '마지막 메시지',
+      sendAt: '2025-04-12 14:38:40'
+    },
+  },
+  {
+    avatar: 'https://picsum.photos/250/300?image=660',
+    name: "유저이름",
+    lastMessage:{
+      message: '마지막 메시지',
+      sendAt: '2024-04-13 14:38:40'
+    },
+  },
+]
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
### 구현된 기능
- 채팅 목록 UI 구현

### 구현된 이미지
<img width="486" alt="스크린샷 2025-04-13 오후 4 25 59" src="https://github.com/user-attachments/assets/43bb87df-48a9-417a-950c-c5943c698ed6" />

### 상세 설명
- 채팅의 마지막 내용을 보여줌
- 마지막 메시지의 보낸시간 표시
  - 오늘이라면 `보낸 시각`을 표시한다.
  - 어제라면 `어제`라고 표시한다.
  - 최근 일주일 이내라면 `보낸 요일`을 표시한다.
  - 이보다 더 과거라면, `보낸 일자`를 표시한다.

### 연관된 이슈
close #5 